### PR TITLE
If you pass non process names return information about all of them

### DIFF
--- a/supervisord_nagios/controllerplugin.py
+++ b/supervisord_nagios/controllerplugin.py
@@ -105,8 +105,9 @@ class NagiosControllerPlugin(ControllerPluginBase):
         options.warn = self._flatten_comma_separated(options.warn)
         options.crit = self._flatten_comma_separated(options.crit)
 
-        if len(options.process) == 0:
-            return [self.UNKNOWN], ['must pass process name(s) to script']
+        if not options.process:
+            for process in self.supervisor.getAllProcessInfo():
+                options.process.append(process['name'])
 
         exit_codes = []
         statuses = []
@@ -115,7 +116,10 @@ class NagiosControllerPlugin(ControllerPluginBase):
             exit_codes.append(exit_code)
             statuses.append(status)
 
-        return [max(exit_codes)], statuses
+        if exit_codes and statuses:
+            return [max(exit_codes)], statuses
+        else:
+            return [self.OK], ["No running process"]
 
     def help_nagios_checkprocess(self):
         self._help(self._get_nagios_checkprocess_parser)


### PR DESCRIPTION
I think it is much convenient to have information about all processes without explicitly specifying any of them:
- Huge process list
- Need to add and remove processes
- Need to change process names relatively often
- and above all to have constant monitoring of all of them without changing check definition every time

So if you have same thoughts be my guest and accept this pull request :)

Regards